### PR TITLE
Doing the walk over the endpoints synchronously - issue #11

### DIFF
--- a/lib/endpoints.js
+++ b/lib/endpoints.js
@@ -7,11 +7,11 @@ exports.load = function(server){
 	//Load all endpoints in the endpoints folder
  	//walk is blocking on purpose because the server is not allowed 
  	//to listen yet
-	fileModule.walk('./endpoints', function(a, dirPath, dirs, files){
+	fileModule.walkSync('./endpoints', function(dirPath, dirs, files){
 		if(files && dirPath.indexOf("/test") < 0){
 			files.forEach(function(file,key){
 				//Setup the endpoint via the setup function
-				require('../'+file).setup(server);
+				require('../'+dirPath+'/'+file).setup(server);
 			});
 		}
 	});


### PR DESCRIPTION
that file library is such big crap..

the function signature for the walk function is totally different despite the documentation.

it doesn't take an empty first param (wtf is with that in the first place)

and it doesn't include the full filename when it's sync, so I had to also concatenate the directory path with the file path.. Hope it's clear from the commit

![screenshot](http://f.cl.ly/items/1S0x1L1V3T0d1C1C3821/Screen%20Shot%202013-05-01%20at%201.34.47%20AM.png)
