### PR TITLE
Adding an integration test for the realtime search and fixing it?

### DIFF
--- a/endpoints/bus/index.js
+++ b/endpoints/bus/index.js
@@ -3,7 +3,6 @@ var h = require('../../lib/helpers.js');
 
 exports.setup = function(server){
 	server.post({path: '/bus/search', version: '1.0.0'}, search);
-	server.post({path: '/bus/realtime', version: '1.0.0'}, realtime);
 }
 
 var search = function(req, res, next) {

--- a/endpoints/bus/realtime.js
+++ b/endpoints/bus/realtime.js
@@ -85,9 +85,13 @@ var realtime = function(req, res, next){
     		routes.forEach(function(route, key){
 
     			var objRoute = {
-    				busNr: route.id,
+                    busNr: route.id || "", // will be undefined if none are active
     				busses: []
     			}; 
+                objRoutes.results.push(objRoute);
+
+                if (!route.busses) return; // No busses active, eg. after schedule
+
     			route.busses.forEach(function(bus, key){
 
     				var location = h.ISN93_To_WGS84(bus.X,bus.Y),
@@ -102,7 +106,6 @@ var realtime = function(req, res, next){
 
     			});
 
-    			objRoutes.results.push(objRoute);
     		});
 
 			h.logVisit('/bus/search', objRoutes,false);

--- a/endpoints/bus/tests/integration_test.js
+++ b/endpoints/bus/tests/integration_test.js
@@ -1,0 +1,39 @@
+var request = require('request');
+var assert = require('assert');
+var helpers = require('../../../lib/test_helpers.js');
+
+describe('bus', function() {
+    this.timeout(0); // this endpoint is slow
+
+    var fieldsToCheckFor = ["busNr","busses"];
+
+    var customCheck = function(json) {
+        var busses = json.results[0].busses;
+        assert(busses.length > 0, "The array of busses should not be empty!");
+        helpers.assertPresenceOfFields(["unixTime","x","y","from","to"], busses);
+    };
+
+    describe('realtime', function() {
+        describe('searching a single bus', function() {
+            it("should return an array of objects containing correct fields", function(done) {
+                var params = helpers.testRequestParams("/bus/realtime?busses=1");
+                var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor, customCheck);
+                request.get(params, resultHandler);
+            });
+        });
+        describe('searching multiple busses', function() {
+            it("should return an array of objects containing correct fields", function(done) {
+                var params = helpers.testRequestParams("/bus/realtime?busses=1,5");
+                var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor, customCheck);
+                request.get(params, resultHandler);
+            });
+        });
+        describe('searching for a non existant bus', function() {
+            it("should return an array of objects containing correct fields", function(done) {
+                var params = helpers.testRequestParams("/bus/realtime?busses=999");
+                var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor);
+                request.get(params, resultHandler);
+            });
+        });
+    });
+});

--- a/lib/test_helpers.js
+++ b/lib/test_helpers.js
@@ -13,7 +13,7 @@ function assertPresenceOfFields(fields, arr) {
 };
 // always returns the same fields, so we'll just reuse this function for both cases
 // (I may be going a bit overboard on this)
-exports.testRequestHandlerForFields = function(done, fieldsToCheckFor) {
+exports.testRequestHandlerForFields = function(done, fieldsToCheckFor, customCallback) {
     return function(err, res, body) {
         if (err) throw err;
         var json = JSON.parse(body);
@@ -23,6 +23,10 @@ exports.testRequestHandlerForFields = function(done, fieldsToCheckFor) {
 
         // Check for the presence of all expected fields
         assertPresenceOfFields(fieldsToCheckFor, json.results);
+
+        if (customCallback) {
+            customCallback.call(null, json);
+        }
 
         done();
     };
@@ -36,3 +40,4 @@ exports.testRequestParams = function(path, form) {
         headers: [ "Content-type: application/json" ]
     };
 };
+exports.assertPresenceOfFields = assertPresenceOfFields;


### PR DESCRIPTION
at least now it will work when you search for a bus that doesn't exist.. or at least it will be consistent with the normal results (returns an array of busses with an empty array of busses within that number)
