### PR TITLE
Allowing the array of busses to be empty in each bus subset

### DIFF
--- a/endpoints/bus/tests/integration_test.js
+++ b/endpoints/bus/tests/integration_test.js
@@ -9,7 +9,7 @@ describe('bus', function() {
 
     var customCheck = function(json) {
         var busses = json.results[0].busses;
-        assert(busses.length > 0, "The array of busses should not be empty!");
+        if (busses.length > 0) return;
         helpers.assertPresenceOfFields(["unixTime","x","y","from","to"], busses);
     };
 


### PR DESCRIPTION
This is kind of tricky.

At off hours, the busses arrays are empty, so we can't make sure they are not empty in the integration test.

Possibly there's a way to check what time it is, though for an integration test you usually want the results to be consistent, and I guess, in a way, they are this way.

Anyways, it's not clear to me what the solution is, but maybe it's a good idea to allow them to be empty now...
