### PR TITLE
Adding configuration environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ endpoints/sms
 endpoints/closed_endpoints
 index.php
 docs
+config/*.config.json

--- a/config/default.json
+++ b/config/default.json
@@ -1,0 +1,4 @@
+{
+    "host": "localhost",
+    "port": 3100
+}

--- a/config/dev.config.json
+++ b/config/dev.config.json
@@ -1,0 +1,4 @@
+{
+    "host": "localhost",
+    "port": 3100
+}

--- a/config/index.js
+++ b/config/index.js
@@ -1,0 +1,6 @@
+var xtend = require('xtend'),
+    env = process.env.NODE_ENV || 'dev',
+    defaultConfig = require('./default.json'),
+    envConfig = require('./' + env + '.config.json');
+
+module.exports = xtend({}, defaultConfig, envConfig);

--- a/lib/test_helpers.js
+++ b/lib/test_helpers.js
@@ -1,4 +1,5 @@
-var assert = require('assert');
+var assert = require('assert'),
+    config = require('../config');
 
 function assertResults(json) {
     assert(json.results && typeof json.results.length !== "undefined", "Does not contain a 'results' field");
@@ -34,7 +35,7 @@ exports.testRequestHandlerForFields = function(done, fieldsToCheckFor, customCal
 // Generate http request params for a particular endpoint
 exports.testRequestParams = function(path, form) {
     return {
-        url: "http://localhost:3100" + path,
+        url: "http://" + config.host + ":" + config.port + path,
         method: "GET",
         form: form,
         headers: [ "Content-type: application/json" ]

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     	"xml2js": "0.2.x",
         "mocha": "~1.8.2",
        	"cheerio": "0.10.x",
-       	"isn2wgs": "0.0.1"
+        "isn2wgs": "0.0.1",
+        "xtend": "2.x"
     },
     "scripts":{
     	"test": "node_modules/mocha/bin/mocha test/integration"

--- a/server.js
+++ b/server.js
@@ -1,6 +1,7 @@
 //The server module
 var restify = require('restify'),
-    server = restify.createServer();
+    server = restify.createServer(),
+    config = require('./config');
 
 //Enables the use of posted params
 server.use(restify.bodyParser({ mapParams: true }));
@@ -25,5 +26,5 @@ server.pre(function(req, res, next) {
 require('./lib/endpoints.js').load(server);
 
 //Start the listener for incoming connections
-server.listen(3100);
-console.log('Server running at port: 3100');
+server.listen(config.port);
+console.log('Server running at port: ' + config.port);


### PR DESCRIPTION
Ok, so I've added some basic form of configuration environment support.

The thing is that I think it will change a bit the server deployment, so I'm not sure if there are better ways to do this.
### Why?

I was going to add email support in the app, but realized that at that point we might need to start putting in passwords etc, which would always be different depending on each user.

We'll also be able to override config for development (like whether or not to log errors to log file, email or whatever) specifically w/o it affecting the production config.

This will make it easier for people to run their server setup on a different port etc, w/o manually changing the port in a few places.
### First, a bit bout the setup:

Environment specific config files (dev, production, testing? etc) are stored in:

```
config/xxx.config.json
```

Global defaults that will always be included are in `config/default.json`

If you want to start the server using a specific configuration, let's say it's called "staging", you'd start the app like this:

NODE_ENV=staging node server.js

So the current server config always depends on which environment you are starting in.

I think this is pretty much the standard way to configure environment specific instances.

I added `config/*.config.json` to `.gitignore` so you can change `dev.config.json` to your liking w/o accidentally checking it into source control.
### Defaults

This setup defaults to the `dev` environment, and I already created that file, so for running the app normally nothing will change.

You can also clear out the `dev.config.json` file (as in so it's just `{}`) and then it will just use the defaults, since it's all inherited.
### The catch

RIght now, as I understand it, we deploy by pulling in the master from github. In order for this to work in production, we'd need to do this on the server after pulling in the changes:
- Create a copy of `config/dev.config.js.example` to `config/production.config.js` file in the config directory on the server.
- always start the server using `NODE_ENV=production forever server.js` (or whatever the command is that we use to start in production.

_Any thoughts?_
