### PR TITLE
Changed default provider from m5 to arion

### DIFF
--- a/endpoints/currency/index.js
+++ b/endpoints/currency/index.js
@@ -3,7 +3,7 @@ var request = require('request'),
     app = require('../../server');
 
 app.get('/currency', function(req, res){
-    var provider = req.query.provider || 'm5'; //m5 determined by a fair dice roll
+    var provider = req.query.provider || 'arion';
     var providers = ['m5', 'arion', 'lb'];
     if (providers.indexOf(provider) >= 0) {
         return res.redirect(301,'/currency/'+ provider);


### PR DESCRIPTION
Made sense to change it from m5 since m5 is returning the least amount of information (no askValue or bidValue)
