### PR TITLE
Markup changes for declension endpoint. Fixes #96.

### DIFF
--- a/endpoints/declension/index.js
+++ b/endpoints/declension/index.js
@@ -1,69 +1,64 @@
-
 // dependencies
 var app = require('../../server'),
 	request = require('request'),
 	helper = require('apis-helpers'),
 	cheerio = require('cheerio'),
-	_ = require('underscore');
+	_ = require('underscore'),
+	url = require('url');
 
-var baseUrl = 'http://bin.arnastofnun.is/',
- query = 'leit/?q=';
-
+var baseUrl = url.parse('http://dev.phpbin.ja.is/ajax_leit.php');
 
 app.get('/declension/:word', function(req, res) {
 	var word = req.params.word;
+	baseUrl.query = {'q': word};
 
-	// request params
 	var params = {
-		url: baseUrl.concat(query, word),
-		headers: { 'User-Agent': helper.browser() }
+		url: url.format(baseUrl),
+		headers: {
+			'User-Agent': helper.browser(),
+		},
 	};
-	
-	
-	return res.json(502,{
-		results: [], type: '',
-		error: "This API endpoint has been temporarily disabled, due to changes in markup at the remote location. Feel free to contribute!",
-		moreinfo: "https://github.com/kristjanmik/apis/issues/96"
-	});
 
 	getDeclensions(function(body) {
 		return res.json(parseTable(body));
-  }, params);
+  	}, params);
 });
 
 // return permutation of a given word
 function getDeclensions(callback, params) {
 	request.get(params, function(err, res, body) {
-
 		if (err || res.statusCode != 200) {
-			throw new Error(err);
+			return res.json(500, {error:'A request to dev.phpbin.ja.is resulted in a error'});
 		}
 
+		body = body.replace(/<!--[\s\S]*?-->/g, '');
 		var $;
 
 		try {
 			$ = cheerio.load(body);
 		} catch(error) {
-			throw new Error(error);
+			return res.json(500, {
+				error: 'Parsing the data from dev.phpbin.ja.is resulted in a error',
+				moreinfo: error
+			});
 		}
 
-		var result = $("#main ul li a");
+		// Links mean reults!
+		var result = $("a");
 
 		// more than 1 result from request (ex: 'hús')
 		if (result.length > 1) {
-
-		// call recursively again with new url
-		params.url = baseUrl.concat(result[0].attribs.href);
-			getDeclensions(callback, params);
-			return;
+			// call recursively again with new url
+			var id = result[0].attribs.on_click.match(/\d+/)[0];
+			baseUrl.query = {'id': id};
+			params.url = url.format(baseUrl);
+			return getDeclensions(callback, params);
 		};
 
 		// else just call func to return data
-		return callback($("#main"));
-
+		return callback($);
 	});
 };
-
 
 // Creates a sequence of integers, each iteration creates a value and increments that value by 1
 // step: specify how often to run the iteration
@@ -76,30 +71,29 @@ function generateSequence(start, step, increment) {
 
 	_.each(_.range(start, step), function(i) {
 		var value = (i + increment * i);
-	
+
 		results.push(value, value + 1);
 	});
 
 	return results;
 };
 
-
-function parseTable(data) {
-	var type = data.find('center:first-child').contents().eq(2).text().trim();
+function parseTable($) {
+	var type = $('small').contents().text().trim();
 
 	// create a sequence which is the same as the index of 'Eintala' of the td's in the HTML table.
 	var singular = generateSequence(0, 4, 3),
 		results = [];
 
-	data.find('table tr td span').each(function(i) {
+	$('table tr td span').each(function(i) {
 		var parent = this.parent();
-		
+
 		results.push({
 			predicate: parent.parent().find('td:first-child').text(),
 			value: this.text(),
 			category: i in singular ? 'Eintala' : 'Fleirtala'
 		});
 	});
-	
+
 	return { results: results, type: type };
 };

--- a/endpoints/declension/tests/integration_test.js
+++ b/endpoints/declension/tests/integration_test.js
@@ -3,11 +3,10 @@ var request = require('request'),
     helpers = require('../../../lib/test_helpers.js');
 
 describe('declension', function() {
-
-    //  it("should return an array of objects containing correct fields", function(done) {
-    //     var fieldsToCheckFor = ["predicate", "value", "category"];
-    //     var params = helpers.testRequestParams("/declension/laugavegur");
-    //     var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor);
-    //     request.get(params, resultHandler);
-    // });
+    it("should return an array of objects containing correct fields", function(done) {
+        var fieldsToCheckFor = ["predicate", "value", "category"];
+        var params = helpers.testRequestParams("/declension/laugavegur");
+        var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor);
+        request.get(params, resultHandler);
+    });
 });


### PR DESCRIPTION
Like in #130 I've had no luck with running the server for manual testing, but the tests pass! So that's something!

Since `bin.arnastofnun.is` calls `dev.phpbin.ja.is` directly I cut out the middle man and call that endpoint directly. It returns HTML and there have been small changes to the markup that should be parsed correctly now.
