### PR TITLE
Make sure cache responses specify charset=utf-8

### DIFF
--- a/lib/cache.js
+++ b/lib/cache.js
@@ -21,8 +21,8 @@ module.exports = function(){
 	        	console.log('Error in caching layer:',error);
 	        	return next();
 	        }else if(reply){
-	        	res.set('Content-Type', 'application/json');
-	            res.end(reply);
+	            res.type('json');
+	            res.send(reply);
 	        }else{
 	            res.cache = function(timeout) {
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "xregexp": "~2.0.0",
     "cheerio": "~0.12.4",
     "mocha": "~1.15.1",
-    "express": "~3.4.8",
+    "express": "~3.20.1",
     "apis-helpers": "0.0.1"
   },
   "scripts": {


### PR DESCRIPTION
This depends on functionality added in express@3.8.0.

Upgraded to newest minor version in the process. Not sure if that’s scary but at least all tests passed.

Fixes #197 