### PR TITLE
Add lottery endpoint from v1.

### DIFF
--- a/endpoints/lottery/docs.json
+++ b/endpoints/lottery/docs.json
@@ -1,0 +1,35 @@
+{
+  "title": "Lottery",
+  "icon": "ticket",
+  "description": "Display the latest lottery numbers",
+  "endpoints": [
+    {
+      "path": "/lottery/lotto",
+      "method": "GET",
+      "description": "Get the lotto numbers",
+      "source": {
+        "title": "Getspá - Getraunir",
+        "path": "https://igvefur.lotto.is/lottoleikir/urslit/lotto/"
+      },
+      "variables": []
+    }, {
+      "path": "/lottery/vikingalotto",
+      "method": "GET",
+      "description": "Get the vikingalotto numbers",
+      "source": {
+        "title": "Getspá - Getraunir",
+        "path": "https://igvefur.lotto.is/lottoleikir/urslit/vikingalotto/"
+      },
+      "variables": []
+    }, {
+      "path": "/lottery/eurojackpot",
+      "method": "GET",
+      "description": "Get the eurojackpot numbers",
+      "source": {
+        "title": "Getspá - Getraunir",
+        "path": "https://igvefur.lotto.is/lottoleikir/urslit/eurojackpot/"
+      },
+      "variables": []
+    },
+  ]
+}

--- a/endpoints/lottery/docs.json
+++ b/endpoints/lottery/docs.json
@@ -30,6 +30,6 @@
         "path": "https://igvefur.lotto.is/lottoleikir/urslit/eurojackpot/"
       },
       "variables": []
-    },
+    }
   ]
 }

--- a/endpoints/lottery/index.js
+++ b/endpoints/lottery/index.js
@@ -1,0 +1,19 @@
+var endpoint = require('apis-endpoint')();
+module.exports = endpoint;
+var lottery = require('icelandic-lottery');
+
+// Lottery route handler
+var lotteryResults = function(req, res) {
+  // Curry the get number function
+  return lottery.getNumbers(function(err, numbers) {
+    if (err) {
+      return res.json({error: err});
+    }
+    return res.json(numbers);
+  }, req.path.substr(1));
+};
+
+// Set up all the endpoints with our generic currying function.
+endpoint.get('/lotto', lotteryResults);
+endpoint.get('/vikingalotto', lotteryResults);
+endpoint.get('/eurojackpot', lotteryResults);

--- a/endpoints/lottery/test.js
+++ b/endpoints/lottery/test.js
@@ -1,0 +1,18 @@
+var endpoint = require('./');
+
+describe('lotto', function() {
+  it('should not error', function(done) {
+    endpoint.tester('/lotto').expect(200, done);
+  });
+});
+
+describe('vikingalotto', function() {
+  it('should not error', function(done) {
+    endpoint.tester('/vikingalotto').expect(200, done);
+  });
+});
+describe('eurojackpot', function() {
+  it('should not error', function(done) {
+    endpoint.tester('/eurojackpot').expect(200, done);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "firm": "^0.2.1",
     "flights": "^0.2.0",
     "gulp": "^3.8.11",
+    "icelandic-lottery": "^1.0.0",
     "statuses": "^1.2.1",
     "tvinna": "^1.0.1",
     "vinbud": "^1.0.1"


### PR DESCRIPTION
In a effort to move all the endpoints into v2 (read "gruntwork"), this is the lottery endpoint added with some refactoring, including that instead of a string containing the numbers spaced out that property will now return a array of integers.

The repo for the actual logic is at [koddsson/icelandic-lottery](https://github.com/koddsson/icelandic-lottery)

Check it out @benediktvaldez @MiniGod & @kristjanmik 