### PR TITLE
Bump the vinbud package version to 1.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp": "^3.8.11",
     "statuses": "^1.2.1",
     "tvinna": "^1.0.1",
-    "vinbud": "^1.1.0"
+    "vinbud": "^1.1.1"
   },
   "devDependencies": {
     "coveralls": "^2.11.2",


### PR DESCRIPTION
@MiniGod This might be why the server hasn't got the latest bug fix for `vinbud` endpoint.

There were a lot of :beers: last night, so I got confused. Sorry :broken_heart: