### PR TITLE
Add a metrics middleware to app

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "cheerio": "~0.12.4",
     "debug": "^2.2.0",
     "express": "^4.13.4",
+    "express-metrics": "^1.1.0",
     "file": "~0.2.1",
     "iconv-lite": "^0.4.13",
     "isn2wgs": "0.0.2",

--- a/server.js
+++ b/server.js
@@ -1,4 +1,6 @@
 import express from 'express';
+import expressMetrics from 'express-metrics';
+
 import fileModule from 'file';
 import { EventEmitter as EE } from 'events';
 
@@ -7,6 +9,10 @@ import cache from './lib/cache';
 import cors from './lib/cors';
 
 var app = express();
+
+app.use(expressMetrics({
+  port: 8091
+}));
 
 module.exports = app;
 


### PR DESCRIPTION
Fixes #245!

Collects metrics and makes 'em available on port 8091 under `/metrics`.