### PR TITLE
Fixing the error handler caused by apis-is#274

### DIFF
--- a/server.js
+++ b/server.js
@@ -63,12 +63,13 @@ fileModule.walkSync('./endpoints', (dirPath, dirs, endpoints) => {
   }
 })
 
-app.use((error, req, res) => {
+app.use((error, req, res, next) => {
   let code = 500
   let message = 'Unknown error'
 
   if (res.headersSent) {
-    message = 'Headers already sent'
+    console.error('Headers already sent')
+    return next()
   }
 
   if (typeof error === 'number') {


### PR DESCRIPTION
Something got messed up when we added eslint