### PR TITLE
Use the provided element in a `.each()` call.

### DIFF
--- a/endpoints/company/index.js
+++ b/endpoints/company/index.js
@@ -37,13 +37,17 @@ app.get('/company', (req, res) => {
         })
       }
     } else {
-      $('table tr').slice(1).each(() => {
-        const td = $(this).find('td')
+      $('table tr').slice(1).each((i, element) => {
+        const td = $(element).find('td')
         const nameRoot = td.eq(1).text()
         const felagAfskrad = '(Félag afskráð)'
 
         obj.results.push({
-          name: nameRoot.replace('\n', '').replace(felagAfskrad, '').replace(/^\s\s*/, '').replace(/\s\s*$/, ''),
+          name: nameRoot
+            .replace('\n', '')
+            .replace(felagAfskrad, '')
+            .replace(/^\s\s*/, '')
+            .replace(/\s\s*$/, ''),
           sn: td.eq(0).text(),
           active: nameRoot.indexOf(felagAfskrad) > -1 ? 0 : 1,
           address: td.eq(2).text(),


### PR DESCRIPTION
Something broke in either a greenkeeper pr or by some code change where using `$(this)` in a cheerio `.each(function() {...})` context doesn't seem to work any more.

Reason why I think it's a greenkeeper PR is because nothing that would cause this seems to have been merged recently.

The solution is to take in the current element as a parameter and using it instead like so: `.each(function(index, element) {...})`.

- [Cheerio `.each(...)`](https://github.com/cheeriojs/cheerio#each-functionindex-element-)

Fixes #286

### Checklist

- [ ] ~~Write tests~~
- [ ] ~~Write documentation~~