### PR TITLE
Added functionality for types of currencies in arion (#294)

### DIFF
--- a/endpoints/currency/arion.js
+++ b/endpoints/currency/arion.js
@@ -3,16 +3,18 @@ import moment from 'moment'
 import h from 'apis-helpers'
 import app from '../../server'
 
-app.get('/currency/arion', (req, res) => {
+app.get('/currency/arion/:type?', (req, res) => {
+  // types: AlmenntGengi,KortaGengi(valitor),SedlaGengi,AirportGengi
+  const type = req.params.type || 'AlmenntGengi'
   let toSend = 'm=GetCurrencies'
+
   toSend += `&beginDate=${moment().subtract(1, 'days').format('YYYY-MM-DD')}`
   toSend += `&finalDate=${moment().format('YYYY-MM-DD')}`
-  toSend += '&currencyType=AlmenntGengi'
+  toSend += `&currencyType=${type}`
   toSend += '&currenciesAvailable=ISK%2CUSD%2CGBP%2CEUR%2CCAD%2CDKK%2CNOK%2CSEK%2CCHF%2CJPY%2CXDR'
-
   request.get({
     headers: { 'content-type': 'application/x-www-form-urlencoded' },
-    url: 'http://www.arionbanki.is/Webservice/PortalCurrency.ashx',
+    url: 'https://www.arionbanki.is/Webservice/PortalCurrency.ashx',
     body: toSend,
   }, (error, response, body) => {
     if (error || response.statusCode !== 200) {

--- a/endpoints/currency/lb.js
+++ b/endpoints/currency/lb.js
@@ -3,12 +3,12 @@ import xml2js from 'xml2js'
 import app from '../../server'
 const parseString = xml2js.parseString
 
-app.get('/currency/lb', (req, res) => {
+app.get('/currency/lb/:type?', (req, res) => {
   // A = Almennt gengi, S = Seðlagengi
   const type = req.params.type || 'A'
 
   request.get({
-    url: `http://www.landsbankinn.is/modules/markets/services/XMLGengi.asmx/NyjastaGengiByType?strTegund=${type}`,
+    url: `https://www.landsbankinn.is/modules/markets/services/XMLGengi.asmx/NyjastaGengiByType?strTegund=${type}`,
   }, (err, response, xml) => {
     if (err || response.statusCode !== 200) {
       return res.status(500).json({ error: 'www.landsbankinn.is refuses to respond or give back data' })


### PR DESCRIPTION
http to https in endpoints currency/arion and currency/lb

Optional parameter for type of currency for endpoint currency/arion

### Checklist

- [ ] Write tests
- [ ] Write documentation

http changed to https

* Allowed types are AlmenntGengi(default),KortaGengi,AirportGengi,SedlaGengi

* Minor fix for types in lb. Changed http to https