### PR TITLE
Add a script to run a single integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
   "scripts": {
     "dev": "nodemon index.js",
     "start": "node index.js",
-    "test": "mocha --reporter=dot ./test",
+    "test": "mocha --reporter=dot ./test/index.js",
     "test-single": "node ./test/run_integration_test_single.js",
     "coveralls": "exit 0",
     "lint": "eslint ."

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "dev": "nodemon index.js",
     "start": "node index.js",
     "test": "mocha --reporter=dot ./test",
+    "test-single": "node ./test/run_integration_test_single.js",
     "coveralls": "exit 0",
     "lint": "eslint ."
   },

--- a/test/integration/run_integration_test_single.js
+++ b/test/integration/run_integration_test_single.js
@@ -1,0 +1,29 @@
+// Turn test mode on
+process.env.INTEGRATION = true
+
+import Mocha from 'mocha'
+import path from 'path'
+import fs from 'fs'
+
+const mocha = new Mocha()
+// process.args[2] is the first argument passed to the script
+const testFile = process.argv[2]
+const testFileAbs = path.join(process.cwd(), testFile)
+
+// Ensure that the testFile exists
+try {
+  fs.accessSync(testFileAbs, fs.F_OK)
+} catch (e) {
+  console.error(`\n[ERROR] file ${testFile} does not exist`)
+}
+
+const app = require(`${process.cwd()}/server`)
+
+app.on('ready', () => {
+  mocha.addFile(testFileAbs)
+  mocha.run(failures => {
+    // exit with non-zero status if there were failures
+    process.on('exit', () => process.exit(failures))
+    process.exit()
+  })
+})

--- a/test/run_integration_test_single.js
+++ b/test/run_integration_test_single.js
@@ -1,0 +1,3 @@
+require('babel-core/register')
+
+require('./integration/run_integration_test_single')


### PR DESCRIPTION
Added a npm script called `test-single` which can be use as:
`npm run test-single -- endpoints/address/tests/integration_test.js` to only run the test which was passed to the script.

 `node test/run_integration_test_single.js <path to test>` will work the same.