### PR TITLE
Add flow type-checking

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,0 +1,1 @@
+flow-typed

--- a/.flowconfig
+++ b/.flowconfig
@@ -1,0 +1,27 @@
+[ignore]
+# ignore problematic modules.
+
+[include]
+
+[libs]
+# defaults to flow-types/
+
+[options]
+# Ignore flow warning about not supporting decorator types fully yet.
+esproposal.decorators=ignore
+# Enable experimental features
+esproposal.class_static_fields=enable
+esproposal.class_instance_fields=enable
+
+module.use_strict=true
+
+# Provides an escape hatch to suppress flow type errors.
+# Example: `function foo(bar: $FlowFixMe) {...}`.
+suppress_type=$FlowFixMe
+
+# Provides a way to suppress flow errors in the following line.
+# Example: // $FlowSuppressError: This following line is borked because of reasons.
+suppress_comment= \\(.\\|\n\\)*\\$FlowSuppressError
+
+[version]
+0.29

--- a/endpoints/address/index.js
+++ b/endpoints/address/index.js
@@ -1,9 +1,10 @@
+// @flow
 import request from 'request'
 import h from 'apis-helpers'
 import app from '../../server'
 import _ from 'lodash'
 
-const lookupAddresses = (address) => new Promise((resolve, reject) => {
+const lookupAddresses = (address: string) => new Promise((resolve, reject) => {
   request.get({
     headers: { 'User-Agent': h.browser() },
     url: `https://api.postur.is/PosturIs/ws.asmx/GetPostals?address=${address}`,

--- a/endpoints/car/index.js
+++ b/endpoints/car/index.js
@@ -1,3 +1,5 @@
+// @flow
+
 import request from 'request'
 import $ from 'cheerio'
 import h from 'apis-helpers'

--- a/flow-typed/index.js
+++ b/flow-typed/index.js
@@ -1,0 +1,4 @@
+export type MixedObject = {
+  [key: String],
+  mixed
+}

--- a/flow-typed/typeConstants.js
+++ b/flow-typed/typeConstants.js
@@ -1,0 +1,3 @@
+/* @flow */
+
+declare var __DEV__: Boolean;

--- a/lib/test_helpers.js
+++ b/lib/test_helpers.js
@@ -1,13 +1,16 @@
-import assert from 'assert'
+// @flow
 
-function assertResults(json, canBeEmpty) {
+import assert from 'assert'
+import type { MixedObject } from '../flow-typed'
+
+function assertResults(json: {results: string}, canBeEmpty: boolean) {
   assert(json.results, "Does not contain a 'results' field")
   if (!canBeEmpty) {
     assert(json.results.length > 0, 'Results are empty')
   }
 }
 
-function assertPresenceOfFields(fields, arr) {
+function assertPresenceOfFields(fields: Array<string>, arr: Array<MixedObject>) {
   arr.forEach((result, i) => {
     fields.forEach((field) => {
       const fieldExists = result[field] !== undefined
@@ -41,10 +44,15 @@ function assertTypesOfFields(fields, arr) {
 
 // always returns the same fields, so we'll just reuse this function for both cases
 // (I may be going a bit overboard on this)
-exports.testRequestHandlerForFields = (done, fieldsToCheckFor, customCallback, canBeEmpty) => {
-  return (err, res, body) => {
+exports.testRequestHandlerForFields = (
+  done: () => void,
+  fieldsToCheckFor: any,
+  customCallback: (json: MixedObject) => any,
+  canBeEmpty: boolean
+) => {
+  return (err: ?Error, res: Object, body: string) => {
     if (err) throw err
-    let json
+    let json = null
     try {
       json = JSON.parse(body)
     } catch (e) {
@@ -74,7 +82,7 @@ exports.testRequestHandlerForFields = (done, fieldsToCheckFor, customCallback, c
   }
 }
 // Generate http request params for a particular endpoint
-exports.testRequestParams = (path, form) => {
+exports.testRequestParams = (path: string, form: string) => {
   return {
     url: `http://localhost:3101${path}`,
     method: 'GET',


### PR DESCRIPTION
This might not be wanted. Just close this PR if you are not interested.

Add foundation static type checking with flow.
enabling advanced auto-completion, error prevention and jump-to-definition (in combination with the `nuclide` atom package from facebook)

![foo](https://cloud.githubusercontent.com/assets/2373958/17176682/64c15ed8-53fd-11e6-9eb2-9d7e99a7d009.gif)

