### PR TITLE
Bus: Rename `res` variable to `response`

### DIFF
--- a/endpoints/address/graphql_schema.js
+++ b/endpoints/address/graphql_schema.js
@@ -30,7 +30,7 @@ const addressType = new GraphQLObjectType({
       description: 'A name for an apartment belonging to this address',
     },
     letter: {
-      type: GraphQLString
+      type: GraphQLString,
     },
   },
 })

--- a/endpoints/bus/realtime.js
+++ b/endpoints/bus/realtime.js
@@ -8,9 +8,10 @@ const isn2wgs = require('isn2wgs')
 const debug = require('debug')('bus/realtime')
 
 const getBusRoutes = (data) => new Promise((resolve, reject) => {
-  request('http://straeto.is/bitar/bus/livemap/json.jsp', function (error, response, body) {
-    if (error || response.statusCode !== 200)
-      return response.status(500).json({ error:'The bus api is down or refuses to respond' })
+  request.get('http://straeto.is/bitar/bus/livemap/json.jsp', function (error, response, body) {
+    if (error || response.statusCode !== 200) {
+      return reject('The bus api is down or refuses to respond')
+    }
 
     var obj
     try {

--- a/endpoints/bus/realtime.js
+++ b/endpoints/bus/realtime.js
@@ -10,7 +10,7 @@ const debug = require('debug')('bus/realtime')
 const getBusRoutes = (data) => new Promise((resolve, reject) => {
   request('http://straeto.is/bitar/bus/livemap/json.jsp', function (error, response, body) {
     if (error || response.statusCode !== 200)
-      return res.status(500).json({ error:'The bus api is down or refuses to respond' })
+      return response.status(500).json({ error:'The bus api is down or refuses to respond' })
 
     var obj
     try {

--- a/endpoints/bus/tests/integration_test.js
+++ b/endpoints/bus/tests/integration_test.js
@@ -1,8 +1,10 @@
 /* eslint-disable */
 
-var request = require('request'),
-  assert = require('assert'),
-  helpers = require('../../../lib/test_helpers.js')
+var request = require('request')
+var assert = require('assert')
+var helpers = require('../../../lib/test_helpers.js')
+var sinon = require('sinon')
+var getBusRoutes = require('../realtime.js').default
 
 describe('bus', function () {
   var fieldsToCheckFor = ['busNr', 'busses']
@@ -10,30 +12,52 @@ describe('bus', function () {
   var customCheck = function (json) {
     var busses = json.results[0].busses
     if (busses.length > 0) return
-    helpers.assertPresenceOfFields(['unixTime', 'x', 'y', 'from', 'to'], busses)
+      helpers.assertPresenceOfFields(['unixTime', 'x', 'y', 'from', 'to'], busses)
   }
 
   describe('realtime', function () {
     describe('searching a single bus', function () {
-        it('should return an array of objects containing correct fields', function (done) {
-            var params = helpers.testRequestParams('/bus/realtime?busses=1')
-            var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor, customCheck)
-            request.get(params, resultHandler)
-          })
+      it('should return an array of objects containing correct fields', function (done) {
+        var params = helpers.testRequestParams('/bus/realtime?busses=1')
+        var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor, customCheck)
+        request.get(params, resultHandler)
       })
+    })
+
     describe('searching multiple busses', function () {
-        it('should return an array of objects containing correct fields', function (done) {
-            var params = helpers.testRequestParams('/bus/realtime?busses=1,5')
-            var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor, customCheck)
-            request.get(params, resultHandler)
-          })
+      it('should return an array of objects containing correct fields', function (done) {
+        var params = helpers.testRequestParams('/bus/realtime?busses=1,5')
+        var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor, customCheck)
+        request.get(params, resultHandler)
       })
+    })
+
     describe('searching for a non existant bus', function () {
-        it('should return an array of objects containing correct fields', function (done) {
-            var params = helpers.testRequestParams('/bus/realtime?busses=999')
-            var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor)
-            request.get(params, resultHandler)
-          })
+      it('should return an array of objects containing correct fields', function (done) {
+        var params = helpers.testRequestParams('/bus/realtime?busses=999')
+        var resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor)
+        request.get(params, resultHandler)
       })
+    })
+
+    describe('when the data source returns an error', () => {
+      before(function(){
+        sinon
+          .stub(request, 'get')
+          .yields('We don\'t want no scrapers around these here parts', null, null)
+      });
+
+      after(function(){
+        request.get.restore();
+      });
+
+      it('should return a appropriate message', (done) => {
+        getBusRoutes({})
+          .then((data) => {
+            should.fail('Got back data even though the data source returned an error')
+          })
+          .catch((error) => done())
+      })
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -83,6 +83,7 @@
     "eslint": "^2.6.0",
     "eslint-config-airbnb": "^6.2.0",
     "eslint-plugin-import": "^1.4.0",
-    "nodemon": "1.9.2"
+    "nodemon": "1.9.2",
+    "sinon": "1.17.5"
   }
 }


### PR DESCRIPTION
~~In some reactor job this variable got renamed and this instance must have been forgotten.~~

This started as a fix where we renamed a variable called `res` to `response` but it ended up not being the solution but rather rejecting the promise [here](https://github.com/apis-is/apis/pull/325/files#diff-30d7399c2b5371e04d892af99233d0bbL13)

Closes #323

### Checklist

- [x] Write tests
- [ ] ~~Write documentation~~
