### PR TITLE
Cache more

### DIFF
--- a/endpoints/bus/realtime.js
+++ b/endpoints/bus/realtime.js
@@ -95,7 +95,7 @@ app.get('/bus/realtime', function (req, res) {
   var data = req.query
 
   getBusRoutes(data).then(
-    (routes) => res.json(routes),
+    (routes) => res.cache(1).json(routes),
     () => res.status(500).json({ error:'Something is wrong with the data provided from the data source' })
   )
 })

--- a/endpoints/concerts/index.js
+++ b/endpoints/concerts/index.js
@@ -24,6 +24,6 @@ app.get('/concerts', (req, res) => {
         'imageSource'
       )
     ))
-    return res.json({ results: filtered })
+    return res.cache(60).json({ results: filtered })
   })
 })

--- a/endpoints/currency/arion.js
+++ b/endpoints/currency/arion.js
@@ -43,6 +43,6 @@ app.get('/currency/arion/:type?', (req, res) => {
       currencies.push(currency)
     })
 
-    return res.json({ results: currencies })
+    return res.cache(60).json({ results: currencies })
   })
 })

--- a/endpoints/currency/borgun.js
+++ b/endpoints/currency/borgun.js
@@ -32,7 +32,7 @@ app.get('/currency/borgun', (req, res) => {
             rateDate: rate.RateDate[0],
           })
         }
-        return res.json({ results: currencies })
+        return res.cache(60).json({ results: currencies })
       })
     }
   )

--- a/endpoints/currency/lb.js
+++ b/endpoints/currency/lb.js
@@ -31,7 +31,7 @@ app.get('/currency/lb/:type?', (req, res) => {
           changePer: parseFloat((parseFloat(arr[i].Breyting) / parseFloat(arr[i].Midgengi)).toFixed(2)),
         })
       }
-      return res.json({ results: currencies })
+      return res.cache(60).json({ results: currencies })
     })
   })
 })

--- a/endpoints/currency/m5.js
+++ b/endpoints/currency/m5.js
@@ -52,6 +52,6 @@ app.get('/currency/m5', (req, res) => {
       }
     })
 
-    return res.json({ results: currencies })
+    return res.cache(60).json({ results: currencies })
   })
 })

--- a/endpoints/cyclecounter/index.js
+++ b/endpoints/cyclecounter/index.js
@@ -22,7 +22,7 @@ app.get('/cyclecounter', (req, res) => {
         Date: result.Date[0],
       })
 
-      return res.json({ results: cyclecounter })
+      return res.cache(5).json({ results: cyclecounter })
     })
   })
 })

--- a/endpoints/declension/index.js
+++ b/endpoints/declension/index.js
@@ -108,6 +108,6 @@ app.get('/declension/:word', (req, res) => {
   }
 
   getDeclensions((body) => {
-    return res.json(parseTable(body))
+    return res.cache(86400).json(parseTable(body))
   }, params)
 })

--- a/endpoints/earthquake/index.js
+++ b/endpoints/earthquake/index.js
@@ -160,7 +160,7 @@ app.get('/earthquake/is', (req, res) => {
       return res.status(500).json({ error: error.toString() })
     }
 
-    return res.json({ results: parseList(body) })
+    return res.cache(60).json({ results: parseList(body) })
   })
 })
 
@@ -172,7 +172,7 @@ app.get('/earthquake/is/sec', (req, res) => {
     if (error) {
       return res.json({ error: error.toString() })
     }
-    return res.json({
+    return res.cache(60).json({
       results: parseJavaScriptVariable(body),
     })
   }, {

--- a/endpoints/sports/index.js
+++ b/endpoints/sports/index.js
@@ -110,7 +110,7 @@ app.get('/sports/football', (req, res) => {
         return res.status(500).json({ error: 'Could not parse the game data' })
       }
 
-      return res.json(obj)
+      return res.cache(60).json(obj)
     }
   )
 })
@@ -157,7 +157,7 @@ function footballLeagues(url, req, res) {
         return res.status(500).json({ error: 'Could not parse the game data' })
       }
 
-      return res.json(obj)
+      return res.cache(60).json(obj)
     }
   )
 }
@@ -248,7 +248,7 @@ app.get('/sports/handball', (req, res) => {
         return res.status(500).json({ error: `Could not parse the game data: ${error}` })
       }
 
-      return res.json(obj)
+      return res.cache(60).json(obj)
     }
   )
 })

--- a/lib/cache.js
+++ b/lib/cache.js
@@ -25,10 +25,14 @@ module.exports = function cache() {
         debug('Error in caching layer:', error)
         return next()
       } else if (reply) {
+        debug('cache HIT for %s', key)
         res.type('json')
         res.send(reply)
       } else {
+        debug('cache MISS for %s', key)
         res.cache = function (timeout = 21600) {
+          debug('will cache response of %s for %d seconds', key, timeout)
+
           res.write = function (chunk, encoding) {
             chunkCache.push(chunk)
             write.call(res, chunk, encoding)

--- a/lib/redis.js
+++ b/lib/redis.js
@@ -3,6 +3,10 @@ const debug = require('debug')('redis')
 
 const redis = Redis.createClient()
 
+redis.on('connect', () => {
+  debug('connected')
+})
+
 redis.on('error', (error) => {
   debug(error)
 })


### PR DESCRIPTION
I noticed that we're getting a lot of traffic on the `/currency` endpoints. The responses are not cached so we're scraping on every request... which triggered me to do this pr.

I mostly just set them to cache for 60 seconds, unless it is some kind of a real-time endpoint where data needs to be fresher than that.