### PR TITLE
fix: enable metrics endpoint

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,7 +32,7 @@ const Raven = require('raven')
 
 Raven.config(SENTRY_URL).install()
 
-if (!process.env.NODE_ENV === 'test') {
+if (process.env.NODE_ENV !== 'test') {
   app.use(expressMetrics({
     port: 8091,
   }))


### PR DESCRIPTION
The if statement to enable it seemed wrong, maybe it got changed in a
lint fix run.