### PR TITLE
Re enable company tests

### DIFF
--- a/endpoints/company/tests/integration_test.js
+++ b/endpoints/company/tests/integration_test.js
@@ -2,7 +2,7 @@
 const request = require('request')
 const helpers = require('../../../lib/test_helpers.js')
 
-describe.skip('company', () => {
+describe('company', () => {
   const fieldsToCheckFor = ['name', 'sn', 'active', 'address']
 
   describe('searching by name', () => {


### PR DESCRIPTION
We originally disabled these because they were flaky but since we cache the datasource now we can enable them again!