### PR TITLE
trim field labels in horses endpoint

### DIFF
--- a/endpoints/horses/index.js
+++ b/endpoints/horses/index.js
@@ -73,7 +73,7 @@ function parseData(htmlPage) {
     { name: 'father', label: 'Sire', value: null },
     { name: 'mother', label: 'Dam', value: null },
   ]
-  const labels = params.map(x => x.label)
+  const labels = params.map(x => x.label.trim())
 
   // we do the following health checks
   // - check if label is in tdElements

--- a/endpoints/horses/tests/integration_test.js
+++ b/endpoints/horses/tests/integration_test.js
@@ -36,7 +36,7 @@ describe('horses', () => {
       .reply(200, fs.readFileSync(`${__dirname}/IS2013182797.fixture`))
       .post('/freezone_horse.jsp', 'fnr=IS1987187700&nafn=&uppruni=&ormerki=&leitahnappur=Search+&leita=1')
       .query({ c: 'EN' })
-      .times(2)
+      .times(3)
       .reply(200, fs.readFileSync(`${__dirname}/IS1987187700.fixture`))
   })
 

--- a/endpoints/horses/tests/integration_test.js
+++ b/endpoints/horses/tests/integration_test.js
@@ -1,6 +1,7 @@
 /* eslint-disable import/extensions */
 const fs = require('fs')
 const nock = require('nock')
+const assert = require('assert')
 const request = require('request')
 const helpers = require('../../../lib/test_helpers.js')
 
@@ -72,6 +73,16 @@ describe('horses', () => {
       const params = helpers.testRequestParams('/horses', { id: 'IS1987187700' })
       const resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor)
       request.get(params, resultHandler)
+    })
+
+    it('should return an array of objects containing the correct color', (done) => {
+      const params = helpers.testRequestParams('/horses', { id: 'IS1987187700' })
+      request.get(params, (error, response, body) => {
+        const json = JSON.parse(body)
+        const results = json.results[0]
+        assert(results.color === 'Palomino with a star flaxen mane and tail')
+        done()
+      })
     })
   })
 })


### PR DESCRIPTION
Trim the labels so that we can find them when looking up in the data table. Some of the fields have a trailing space resulting in `null` values since those labels don't exists in the DOM.

### Checklist

- [x] Write tests
- [ ] ~~Write documentation~~

Fixes #407 
