### PR TITLE
Added /stadfang endpoint

### DIFF
--- a/endpoints/stadfang/documentation.md
+++ b/endpoints/stadfang/documentation.md
@@ -1,0 +1,24 @@
+# Icelandic access address (is: Staðfang)
+
+Source [Icelandic National Registry](https://skra.is/einstaklingar/gagnagrusk/nidurhal/)
+
+-  GET [/stadfang](https://apis.is/stadfang)
+
+Lookup addresses in Iceland
+
+NB: At least one of the following is required:  
+`address`, `zipCode`, `street`, `number`, `letter`, `landNumber` or coordinates (`latitude` and `longitude`)
+
+| Parameters | Description                                   | Example                                                                                        |
+|------------|-----------------------------------------------|------------------------------------------------------------------------------------------------|
+| Address    | Address                                       | [Ármúli 42](https://apis.is/stadfang/?address=Ármúli%2042)                                     |
+| ZipCode    | Zip code                                      | [101](https://apis.is/stadfang/?zipCode=101)                                                   |
+| Street     | Street name                                   | [Ármúla](https://apis.is/stadfang/?street=Ármúla)                                              |
+| Number     | Street number (preferably used with `street`) | [Ármúla 1](https://apis.is/stadfang/?street=Ármúla&number=42)                                  |
+| Letter     | Street letter (preferably used with `number`) | [Ármúla 1a](https://apis.is/stadfang/?street=Ármúla&number=1&letter=a)                         |
+| LandNumber | Land number                                   | [103836](https://apis.is/stadfang/?landNumber=103836)                                          |
+| Latitude   | Latitude (must be used with `longitude`)      | [64.1334712, -21.8742527](https://apis.is/stadfang/?latitude=64.1334712&longitude=-21.8742527) |
+| Longitude  | Longitude (must be used with `latitude`)      | [64.1499828, -21.9432083](https://apis.is/stadfang/?latitude=64.1499828&longitude=-21.9432083) |
+| Radius     | Radius distance in KM, default is '1.0'       | [0.2](https://apis.is/stadfang/?latitude=64.1334712&longitude=-21.8742527&radius=0.2)          |
+
+---

--- a/endpoints/stadfang/index.js
+++ b/endpoints/stadfang/index.js
@@ -1,0 +1,110 @@
+const app = require('../../server')
+const stadfang = require('./stadfang')
+
+/*
+source: https://skra.is/library/Samnyttar-skrar-/Fyrirtaeki-stofnanir/Nidurhal/Sta%C3%B0fangaskr%C3%A1%20eigindal%C3%BDsing.pdf
+
+0 landnr
+1 fasteignaheiti
+2 postnr
+3 heiti_nf
+4 heiti_tgf
+5 husnr
+6 bokst
+7 lat_wgs84
+8 long_wgs84
+
+Example: 103836;Ármúli 42;108;Ármúli;Ármúla;42;;64.13349537;-21.87428225
+*/
+
+const haversineDistanceInKm = (coords1, coords2) => {
+  const toRad = x => (x * Math.PI / 180)
+  const R = 6371 // km
+
+  const lon1 = coords1[0]
+  const lat1 = coords1[1]
+  const lon2 = coords2[0]
+  const lat2 = coords2[1]
+
+  const x1 = lat2 - lat1
+  const x2 = lon2 - lon1
+  const dLat = toRad(x1)
+  const dLon = toRad(x2)
+  const a = (
+    Math.sin(dLat / 2) * Math.sin(dLat / 2)
+  ) + (
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) *
+    Math.sin(dLon / 2) * Math.sin(dLon / 2)
+  )
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a))
+  const d = R * c
+
+  return d
+}
+
+const isValidCoordinate = x => (/^-?([1-8]?[1-9]|[1-9]0)\.{1}\d{1,6}/.test(x))
+
+const getFilteredResults = (address, zipCode, street, number, letter, landNumber, coordinates, radius) => {
+  const results = []
+  for (let i = 0; i < stadfang.length; i++) {
+    // Split string like '103836;Ármúli 42;108;Ármúli;Ármúla;42;;64.13349537;-21.87428225' into parts
+    const part = stadfang[i].split(';')
+    // Convert the parts into an object
+    const item = {
+      address: part[1],
+      zipCode: part[2],
+      streetNf: part[3],
+      streetThf: part[4],
+      houseNumber: part[5],
+      houseLetter: part[6],
+      landNumber: part[0],
+      coordinates: [parseFloat(part[7]), parseFloat(part[8])]
+    }
+
+    // The actual filtering
+    if (
+      (address === '' || address === item.address.toLowerCase()) &&
+      (zipCode === '' || zipCode === item.zipCode) &&
+      (street === '' || street === item.streetNf.toLowerCase() || street === item.streetThf.toLowerCase()) &&
+      (number === '' || number === item.houseNumber) &&
+      (letter === '' || letter === item.houseLetter.toLowerCase()) &&
+      (landNumber === '' || landNumber === item.landNumber) &&
+      (coordinates.length === 0 || haversineDistanceInKm(item.coordinates, coordinates) < radius)
+    ) {
+      results.push(item)
+    }
+  }
+
+  return results
+}
+
+app.get('/stadfang', (req, res) => {
+  const address = (req.query.address || '').toLowerCase()
+  const zipCode = req.query.zipCode || ''
+  const street = (req.query.street || '').toLowerCase()
+  const number = req.query.number || ''
+  const letter = (req.query.letter || '').toLowerCase()
+  const landNumber = req.query.landNumber || ''
+  const latitude = req.query.latitude || ''
+  const longitude = req.query.longitude || ''
+  const radius = parseFloat(req.query.radius || '1.0')
+
+  const coordinates = []
+  if (latitude !== '' && longitude !== '' && isValidCoordinate(latitude) && isValidCoordinate(longitude)) {
+    coordinates.push(parseFloat(latitude))
+    coordinates.push(parseFloat(longitude))
+  }
+
+  // Check if no parameters were provided
+  if ([address, zipCode, street, number, letter, landNumber].every(x => x === '') && coordinates.length === 0) {
+    return res.status(400).json({ error: 'No parameters were provided' })
+  }
+
+  const obj = {
+    results: []
+  }
+
+  obj.results = getFilteredResults(address, zipCode, street, number, letter, landNumber, coordinates, radius)
+
+  return res.json(obj)
+})

--- a/endpoints/stadfang/tests/integration_test.js
+++ b/endpoints/stadfang/tests/integration_test.js
@@ -1,0 +1,11 @@
+const request = require('request')
+const helpers = require('../../../lib/test_helpers')
+
+describe('stadfang/', () => {
+  it('should return an array of objects containing correct fields', (done) => {
+    const fieldsToCheckFor = ['address', 'zipCode', 'streetNf', 'streetThf', 'houseNumber', 'houseLetter', 'landNumber', 'coordinates']
+    const params = helpers.testRequestParams('/stadfang', { address: 'laugavegur 26' })
+    const resultHandler = helpers.testRequestHandlerForFields(done, fieldsToCheckFor)
+    request.get(params, resultHandler)
+  })
+})


### PR DESCRIPTION
New endpoint, here is an old issue about it: #242 

Just like /calendar it's not a scraper but it has all the data in `stadfang.js` which exports an array of strings. 118907 items to be exact.

Example of a string:
`103836;Ármúli 42;108;Ármúli;Ármúla;42;;64.13349537;-21.87428225`
It's split into:
`landNumber;address;zipCode;streetNf;streetThf;houseNumber;houseLetter;latitude;longitude`

Like described in the docs at least one of the filter parameters must be provided:
`address`, `zipCode`, `street`, `number`, `letter`, `landNumber` or coordinates (`latitude` and `longitude`)

Only optional is `radius` which is only used when coordinates are provided and default value is '1.0'

### Checklist

- [x] Write tests
- [x] Write documentation
