### PR TITLE
Better ops for production

### DIFF
--- a/lib/redis.js
+++ b/lib/redis.js
@@ -1,7 +1,7 @@
 const Redis = require('redis')
 const debug = require('debug')('redis')
 
-const redis = Redis.createClient()
+const redis = Redis.createClient(process.env.REDIS_URL)
 
 redis.on('connect', () => {
   debug('connected')

--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
   "scripts": {
     "dev": "nodemon server.js",
     "start": "DEBUG=server node server.js",
-    "test": "NODE_ENV=testing mocha --exit --timeout 10000 --reporter=dot ./lib/*.spec.js ./test.js ./endpoints/*/tests/integration_test.js",
+    "test": "NODE_ENV=test mocha --exit --timeout 10000 --reporter=dot ./lib/*.spec.js ./test.js ./endpoints/*/tests/integration_test.js",
     "coveralls": "exit 0",
     "lint": "xo"
   },

--- a/server.js
+++ b/server.js
@@ -116,7 +116,8 @@ app.use((error, req, res, next) => {
 /**
  * Start the server
  */
-const port = process.env.NODE_ENV === 'testing' ? 3101 : 3100
+const port =
+  process.env.PORT || (process.env.NODE_ENV === 'test' ? 3101 : 3100)
 app.listen(port, () => {
   app.emit('ready')
 })

--- a/server.js
+++ b/server.js
@@ -4,12 +4,6 @@
 /* eslint-disable prefer-destructuring */
 /* eslint-disable import/first */
 /* eslint-disable new-cap */
-/**
- * Only for apis.is production environment
- */
-if (process.env.NODE_ENV === 'production') {
-  process.chdir('/apis/current')
-}
 
 const { EventEmitter: EE } = require('events')
 const express = require('express')


### PR DESCRIPTION
* Removed changing of directories when running in production.
* Use `PORT` env variable to change what port the server listens to.
* Use `REDIS_URL` env variable to change what redis server to connect to.

Also changed `NODE_ENV` to be `'test'` when running the tests which is generally more common probably.